### PR TITLE
Add kernel to mapping

### DIFF
--- a/.github/workflows/python-can-run-main.yml
+++ b/.github/workflows/python-can-run-main.yml
@@ -25,4 +25,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run without errors
         run: |
-          python main_stream_ga.py
+          python main_aie_ga.py

--- a/main_aie_ga.py
+++ b/main_aie_ga.py
@@ -12,11 +12,9 @@ _logging_format = "%(asctime)s - %(name)s.%(funcName)s +%(lineno)s - %(levelname
 _logging.basicConfig(level=_logging_level, format=_logging_format)
 
 ############################################INPUTS############################################
-workload_path = "stream/inputs/aie/workload/test_gemm.onnx"
-# accelerator = "stream/inputs/aie/hardware/single_aie_tile.yaml"
-# mapping_path = "stream/inputs/aie/mapping/single_aie_tile.yaml"
-accelerator = "stream/inputs/aie/hardware/single_aie_col.yaml"
-mapping_path = "stream/inputs/aie/mapping/single_aie_col.yaml"
+workload_path = "stream/inputs/aie/workload/conv1x1_64_64_32_32.onnx"
+accelerator = "stream/inputs/aie/hardware/single_aie_tile.yaml"
+mapping_path = "stream/inputs/aie/mapping/single_aie_tile.yaml"
 mode = "lbl"
 layer_stacks = [(0,)]
 nb_ga_generations = 16

--- a/stream/compiler/transforms/convert_stream_to_aie.py
+++ b/stream/compiler/transforms/convert_stream_to_aie.py
@@ -1,7 +1,7 @@
 from xdsl.context import MLContext
-from xdsl.dialects.builtin import FunctionType, IntegerAttr, MemRefType, ModuleOp, StringAttr, i32
+from xdsl.dialects.builtin import IntegerAttr, MemRefType, ModuleOp, i32
 from xdsl.dialects.func import CallOp, FuncOp
-from xdsl.ir import Attribute, OpResult, Region
+from xdsl.ir import Region
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -16,10 +16,10 @@ from xdsl_aie.dialects.aie import (
     Block,
     CoreOp,
     DeviceOp,
-    ObjectFIFOReleaseOp,
     ObjectFifoAcquireOp,
     ObjectFifoOp,
     ObjectFifoPortEnum,
+    ObjectFIFOReleaseOp,
     SymbolTable,
     TileOp,
 )

--- a/stream/hardware/architecture/core.py
+++ b/stream/hardware/architecture/core.py
@@ -7,7 +7,6 @@ class Core(ZigZagCore):
 
     def __init__(self, args: Any):
         super().__init__(**args)
-        self.utilization = 100
         self.type = "compute"
 
     def __eq__(self, other: object) -> bool:

--- a/stream/inputs/aie/hardware/cores/aie_tile.yaml
+++ b/stream/inputs/aie/hardware/cores/aie_tile.yaml
@@ -1,4 +1,5 @@
 name: aie_tile
+type: compute
 
 memories:
   rf_iw:
@@ -76,5 +77,3 @@ dataflows:
     - D, 2
     - C, 8
     - K, 8
-
-utilization: 30.9

--- a/stream/inputs/aie/hardware/single_aie_col_with_mem_tile.yaml
+++ b/stream/inputs/aie/hardware/single_aie_col_with_mem_tile.yaml
@@ -1,0 +1,13 @@
+name: single_aie_col
+cores:
+  0: aie_tile.yaml
+  1: aie_tile.yaml
+  2: aie_tile.yaml
+  3: aie_tile.yaml
+  4: mem_tile_256KB.yaml
+offchip_core: shim_dma.yaml
+core_connectivity:
+  - 0, 1, 2, 3, 4
+bandwidth: 512
+unit_energy_cost: 0
+

--- a/stream/inputs/aie/hardware/single_aie_tile.yaml
+++ b/stream/inputs/aie/hardware/single_aie_tile.yaml
@@ -1,7 +1,8 @@
 name: single_aie_tile
 cores:
-  0: aie_tile.yaml
+  2: aie_tile.yaml
 offchip_core: shim_dma.yaml
+offchip_core_id: 0
 core_connectivity: []
 bandwidth: 512
 unit_energy_cost: 0

--- a/stream/inputs/aie/mapping/single_aie_tile.yaml
+++ b/stream/inputs/aie/mapping/single_aie_tile.yaml
@@ -1,15 +1,31 @@
 - name: default
-  core_allocation: [0]
+  core_allocation: [2]
   intra_core_tiling:
     - OY, 32
   inter_core_tiling:
     - K, *
+  kernel:
+    name: default_kernel
+    utilization: 44.33 
 
 - name: Gemm
-  core_allocation: [0]
+  core_allocation: [2]
   intra_core_tiling:
     - D, 8
   inter_core_tiling:
     - K, *
+  kernel:
+    name: gemm_kernel
+    utilization: 61.8 
+
+- name: Conv
+  core_allocation: [2]
+  intra_core_tiling:
+    - OY, 32
+  inter_core_tiling:
+    - K, 1
+  kernel:
+    name: conv_kernel
+    utilization: 44.33 
 
     

--- a/stream/opt/allocation/genetic_algorithm/fitness_evaluator.py
+++ b/stream/opt/allocation/genetic_algorithm/fitness_evaluator.py
@@ -88,9 +88,9 @@ class StandardFitnessEvaluator(FitnessEvaluator):
                 assert equal_unique_node is not None, "Node not found in CostModelEvaluationLUT"
                 cme = self.cost_lut.get_cme(equal_unique_node, core)
                 onchip_energy = cme.energy_total  # Initialize on-chip energy as total energy
-                latency = cme.ideal_temporal_cycle
+                latency = cme.ideal_cycle
                 # Scale latency based on core utilization
-                latency = latency * 100 / core.utilization
+                latency = int(latency * 100 / node.kernel.utilization)
                 too_large_operands = get_too_large_operands(cme, self.accelerator, core_id=core_allocation)
                 # If there is a too_large_operand, we separate the off-chip energy.
                 offchip_energy = 0
@@ -105,7 +105,7 @@ class StandardFitnessEvaluator(FitnessEvaluator):
                 required_offchip_bandwidth = get_required_offchip_bandwidth(cme, too_large_operands)
                 node.set_onchip_energy(onchip_energy)
                 node.set_offchip_energy(offchip_energy)
-                node.set_runtime(int(latency))
+                node.set_runtime(latency)
                 node.set_chosen_core_allocation(core_allocation)
                 node.set_too_large_operands(too_large_operands)
                 node.set_offchip_bandwidth(required_offchip_bandwidth)

--- a/stream/parser/accelerator_validator.py
+++ b/stream/parser/accelerator_validator.py
@@ -26,6 +26,7 @@ class AcceleratorValidator:
             "valuesrules": {"type": "string", "regex": FILENAME_REGEX},
         },
         "offchip_core": {"type": "string", "regex": FILENAME_REGEX, "required": False},
+        "offchip_core_id": {"type": "integer", "required": False},
         "unit_energy_cost": {"type": "float", "default": 0},
         "bandwidth": {"type": "float", "required": True},
         "core_connectivity": {"type": "list", "required": True, "schema": {"type": "string", "regex": CORE_IDS_REGEX}},
@@ -71,8 +72,6 @@ class AcceleratorValidator:
         core_ids = list(self.data["cores"].keys())
         if not all(isinstance(core_id, int) and core_id >= 0 for core_id in core_ids):
             self.invalidate("Invalid core id in `cores`: id is not a positive integer.")
-        if len(core_ids) != max(core_ids) + 1:
-            self.invalidate("Invalid core id in `cores`: not all core ids in range are in use.")
 
     def validate_all_cores(self) -> None:
         """For all given core file paths:
@@ -105,7 +104,7 @@ class AcceleratorValidator:
         core_validator = CoreValidator(core_data)
         validate_success = core_validator.validate()
         if not validate_success:
-            self.invalidate(f"User-given core  {core_file_name} cannot be validated.")
+            self.invalidate(f"User-given core {core_file_name} cannot be validated.")
 
         # Fill in default values
         normalized_core_data = core_validator.normalized_data

--- a/stream/parser/core_validator.py
+++ b/stream/parser/core_validator.py
@@ -9,9 +9,9 @@ class CoreValidator(ZigZagAcceleratorValidator):
     SCHEMA = ZigZagAcceleratorValidator.SCHEMA.copy()
 
     # Add custom schema rules for Stream accelerator cores here
-    SCHEMA.update({"utilization": {"type": "float", "required": False}})
     SCHEMA.update({"type": {"type": "string", "required": False, "allowed": ["memory", "compute"]}})
 
     def __init__(self, data: Any):
         """Initialize Validator object, assign schema and store normalize user-given data"""
         super().__init__(data)
+        self.validator.schema = CoreValidator.SCHEMA

--- a/stream/parser/mapping_factory.py
+++ b/stream/parser/mapping_factory.py
@@ -10,6 +10,7 @@ from zigzag.mapping.spatial_mapping import (
     SpatialMapping,
 )
 
+from stream.workload.kernel import AIEKernel
 from stream.workload.mapping import TILING_T, InterCoreMappingAttributes
 
 
@@ -28,6 +29,7 @@ class MappingFactory:
             spatial_mapping = self.create_spatial_mapping(mapping_data)
             inter_core_tiling = self.create_inter_core_tiling(mapping_data)
             intra_core_tiling = self.create_intra_core_tiling(mapping_data)
+            kernel = self.create_kernel(mapping_data)
             mapping = InterCoreMappingAttributes(
                 op_type=op_type,
                 spatial_mapping=spatial_mapping,
@@ -35,9 +37,16 @@ class MappingFactory:
                 core_allocation_is_fixed=core_allocation_is_fixed,
                 inter_core_tiling=inter_core_tiling,
                 intra_core_tiling=intra_core_tiling,
+                kernel=kernel,
             )
             all_mappings[op_type] = mapping
         return all_mappings
+
+    def create_kernel(self, mapping_data: dict[str, Any]) -> AIEKernel:
+        return AIEKernel(
+            name=mapping_data["kernel"]["name"],
+            utilization=mapping_data["kernel"]["utilization"],
+        )
 
     def create_spatial_mapping(self, mapping_data: dict[str, Any]) -> SpatialMapping:
         if mapping_data["spatial_mapping"] is None:

--- a/stream/parser/mapping_validator.py
+++ b/stream/parser/mapping_validator.py
@@ -32,6 +32,14 @@ class MappingValidator:
             "schema": {"type": "string", "regex": TILING_REGEX},
             "default": [],
         },
+        "kernel": {
+            "type": "dict",
+            "schema": {
+                "name": {"type": "string", "required": True},
+                "utilization": {"type": "float", "required": True},
+            },
+            "required": True,
+        },
         "spatial_mapping": {
             "type": "dict",
             "schema": {

--- a/stream/stages/codegen/aie_code_generation.py
+++ b/stream/stages/codegen/aie_code_generation.py
@@ -104,6 +104,5 @@ class AIECodeGenerationStage(Stage):
 
         ConvertZigZagToAIEPass().apply(self.context, module)
 
-
     def is_leaf(self) -> bool:
         return False

--- a/stream/stages/set_fixed_allocation_performance.py
+++ b/stream/stages/set_fixed_allocation_performance.py
@@ -59,9 +59,9 @@ class SetFixedAllocationPerformanceStage(Stage):
                 assert equal_node is not None, f"{node} has fixed allocation but no equal node found."
                 core = self.accelerator.get_core(core_id)
                 cme = self.cost_lut.get_cme(equal_node, core)
-                latency = int(cme.ideal_temporal_cycle)
+                latency = int(cme.ideal_cycle)
                 # Scale latency based on utilization of core
-                latency = latency * 100 / core.utilization
+                latency = int(latency * 100 / node.kernel.utilization)
                 too_large_operands = get_too_large_operands(cme, self.accelerator, core_id=core_id)
                 onchip_energy, offchip_energy = self.get_energy_distribution(cme, too_large_operands)
                 # Get the required offchip bandwidth during the execution of the node for all directions

--- a/stream/visualization/cost_model_evaluation_lut.py
+++ b/stream/visualization/cost_model_evaluation_lut.py
@@ -62,12 +62,12 @@ def visualize_cost_lut_pickle(pickle_filepath, scale_factors=None, fig_path=None
 
     if isinstance(pickle_filepath, str):
         with open(pickle_filepath, "rb") as handle:
-            node_hw_performances = pickle.load(handle)
+            cost_lut = pickle.load(handle)
     else:
-        node_hw_performances = pickle_filepath
+        cost_lut = pickle_filepath
 
     if not scale_factors:
-        scale_factors = {node: 1 for node in node_hw_performances}
+        scale_factors = {node: 1 for node in cost_lut.get_nodes()}
 
     if not fig_path:
         basename = os.path.basename(pickle_filepath).split(".")[0]
@@ -77,12 +77,12 @@ def visualize_cost_lut_pickle(pickle_filepath, scale_factors=None, fig_path=None
     cores = []
     min_latency_per_node = {}
     min_energy_per_node = {}
-    for node in node_hw_performances.get_nodes():
+    for node in cost_lut.get_nodes():
         node_labels.append(f"L{node.id}\nN{node.sub_id}\nx{scale_factors[node]}")
         min_latency_per_node[node] = float("inf")
         min_energy_per_node[node] = float("inf")
-        for core in node_hw_performances.get_cores(node):
-            cme = node_hw_performances.get_cme(node, core)
+        for core in cost_lut.get_cores(node):
+            cme = cost_lut.get_cme(node, core)
             if core not in cores:
                 cores.append(core)
             if cme.latency_total2 < min_latency_per_node[node]:
@@ -110,10 +110,10 @@ def visualize_cost_lut_pickle(pickle_filepath, scale_factors=None, fig_path=None
     for core, offset in zip(cores, offsets):
         core_latencies = []
         core_energies = []
-        for node in node_hw_performances.get_nodes():
-            node_cores = node_hw_performances.get_cores(node)
+        for node in cost_lut.get_nodes():
+            node_cores = cost_lut.get_cores(node)
             if core in node_cores:
-                cme = node_hw_performances.get_cme(node, core)
+                cme = cost_lut.get_cme(node, core)
                 core_latencies.append(scale_factors[node] * cme.latency_total2)
                 core_energies.append(scale_factors[node] * cme.energy_total)
             else:

--- a/stream/workload/computation/computation_node.py
+++ b/stream/workload/computation/computation_node.py
@@ -85,6 +85,7 @@ class ComputationNode(LayerNode, Node):
         self.core_allocation_is_fixed = mapping_attr.core_allocation_is_fixed
         self.intra_core_tiling = mapping_attr.intra_core_tiling
         self.inter_core_tiling = mapping_attr.inter_core_tiling
+        self.kernel = mapping_attr.kernel
 
         self.sub_id = sub_id
         self.group = group_id
@@ -174,6 +175,9 @@ class ComputationNode(LayerNode, Node):
 
     def __str__(self):
         return f"ComputationNode{self.id}_{self.sub_id}"
+
+    def __repr__(self):
+        return str(self)
 
     def __hash__(self) -> int:
         """The hash operator of a node.
@@ -284,6 +288,7 @@ class ComputationNode(LayerNode, Node):
             core_allocation_is_fixed=self.core_allocation_is_fixed,
             intra_core_tiling=self.intra_core_tiling,
             inter_core_tiling=self.inter_core_tiling,
+            kernel=self.kernel,
         )
         return deepcopy(mapping_attr)
 

--- a/stream/workload/kernel.py
+++ b/stream/workload/kernel.py
@@ -1,0 +1,4 @@
+class AIEKernel:
+    def __init__(self, name: str, utilization: float):
+        self.name = name
+        self.utilization = utilization

--- a/stream/workload/mapping.py
+++ b/stream/workload/mapping.py
@@ -12,6 +12,8 @@ from zigzag.workload.layer_attributes import (
 )
 from zigzag.workload.layer_node import MappingAttributes as IntraCoreMappingAttributes
 
+from stream.workload.kernel import AIEKernel
+
 TILING_T: TypeAlias = list[tuple[LayerDim, int | Literal["*", "all"]]]
 
 INTRA_CORE_MAPPING_DEFAULT = IntraCoreMappingAttributes(
@@ -36,3 +38,4 @@ class InterCoreMappingAttributes:
     core_allocation_is_fixed: bool
     intra_core_tiling: TILING_T
     inter_core_tiling: TILING_T
+    kernel: AIEKernel


### PR DESCRIPTION
This PR moves the kernel utilization from 'Core' to a new 'kernel' field inside of the mapping input. 
This allows to have different kernel names and utilizations defined for different operator types (which will use different AIE kernels).
