### PR TITLE
add mlir-aie-submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mlir-aie"]
+	path = mlir-aie
+	url = git@github.com:KULeuven-MICAS/mlir-aie.git

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+# Install stream requirements
+pip install -r requirements.txt
+
+# Install mlir-aie nightly
+python3 -m pip install --upgrade pip
+
+# Install IRON library and mlir-aie from a wheel
+python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels
+
+# Install Peano from llvm-aie wheel
+python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+
+# Install basic Python requirements (still needed for release v1.0, but is no longer needed for latest wheels)
+python3 -m pip install -r mlir-aie/python/requirements.txt
+
+# Install MLIR Python Extras
+HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r mlir-aie/python/requirements_extras.txt
+
+# Source mlir-aie environment
+source mlir-aie/utils/env_setup.sh


### PR DESCRIPTION
This adds a fork of mlir-aie (at kuleuven-micas) as a submodule to this repository, such that we can use the scripts inside.
This is needed to integrate tracing into our flow without rewriting the logic ourselves.

@asyms  I think it is also a good idea with an automated CI in mind to use this submodule repository instead of your local one in the makefiles to run the automations.

Also supplies a setup script that can be run to setup the entire environment with stream+mlir-aie all in one