### PR TITLE
add tracing script

### DIFF
--- a/stream/compiler/transforms/aie_add_tracing_script.py
+++ b/stream/compiler/transforms/aie_add_tracing_script.py
@@ -1,0 +1,119 @@
+from xdsl.context import Context
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import Operation
+from xdsl.parser import Parser
+from xdsl.passes import ModulePass
+from xdsl.rewriter import InsertPoint, Rewriter
+from xdsl_aie.dialects.aie import DeviceOp, TileOp
+from xdsl_aie.dialects.aiex import RuntimeSequenceOp
+
+
+class AIEAddTracingScript(ModulePass):
+    name = "aie-add-tracing-script"
+
+    trace_size = 65536
+
+    def apply(self, ctx: Context, op: ModuleOp) -> None:
+        import aie.utils.trace as trace_utils
+        from aie.dialects.aie import AIEDevice, device, tile
+        from aie.extras.context import mlir_mod_ctx
+
+        rewriter = Rewriter()
+
+        # 1: Get packet flow
+        # find shim tile and compute tile:
+        shim_tile = None
+        compute_tile2 = None
+        for tile_op in op.walk():
+            if isinstance(tile_op, TileOp):
+                match (tile_op.col.value.data, tile_op.row.value.data):
+                    case (0, 0):
+                        shim_tile = tile_op
+                    case (0, 2):
+                        compute_tile2 = tile_op
+        assert shim_tile is not None
+        assert compute_tile2 is not None
+
+        with mlir_mod_ctx() as aie_ctx:
+
+            @device(AIEDevice.npu2)
+            def device_body():
+                shim_tile_aie = tile(0, 0)
+                compute_tile2_aie = tile(0, 2)
+                tiles_to_trace = [compute_tile2_aie]
+                trace_utils.configure_packet_tracing_flow(tiles_to_trace, shim_tile_aie)
+
+        packet_flow_str = aie_ctx.module.body.operations[0].get_asm(print_generic_op_form=True)
+
+        # modify to fit into our own IR:
+        parser = Parser(Context(allow_unregistered=True), packet_flow_str)
+        module = parser.parse_module()
+        packet_flow_op = module.body.block.first_op.regions[0].block.last_op.prev_op  # pyright: ignore
+        assert isinstance(packet_flow_op, Operation)
+        packet_flow_op.detach()
+        packet_flow_op.regions[0].block.first_op.operands[0] = compute_tile2.result
+        packet_flow_op.regions[0].block.first_op.next_op.operands[0] = shim_tile.result
+
+        # insert into device body:
+        for device_op in op.walk():
+            if isinstance(device_op, DeviceOp):
+                rewriter.insert_op(packet_flow_op, InsertPoint.at_end(device_op.region.block))
+
+        # 2: Runtime sequence thingies
+        #
+        with mlir_mod_ctx() as aie_ctx:
+
+            @device(AIEDevice.npu2)
+            def device_body():
+                shim_tile_aie = tile(0, 0)
+                compute_tile2_aie = tile(0, 2)
+
+                tiles_to_trace = [compute_tile2_aie]
+
+                trace_utils.configure_packet_tracing_aie2(
+                    tiles_to_trace=tiles_to_trace,
+                    shim=shim_tile_aie,
+                    trace_size=self.trace_size,
+                    coretile_events=[
+                        # captures input A (PORT_RUNNING_0, at port number 1, master for inputs)
+                        trace_utils.PortEvent(
+                            trace_utils.CoreEvent.PORT_RUNNING_0,
+                            port_number=1,
+                            master=True,
+                        ),
+                        # captures input B (PORT_RUNNING_1, at port number 2, master for inputs)
+                        trace_utils.PortEvent(
+                            trace_utils.CoreEvent.PORT_RUNNING_1,
+                            port_number=2,
+                            master=True,
+                        ),
+                        # captures output C (PORT_RUNNING_2, at port number 1, slave for outputs)
+                        trace_utils.PortEvent(
+                            trace_utils.CoreEvent.PORT_RUNNING_2,
+                            port_number=1,
+                            master=False,
+                        ),
+                        trace_utils.CoreEvent.INSTR_EVENT_0,
+                        trace_utils.CoreEvent.INSTR_EVENT_1,
+                        trace_utils.CoreEvent.MEMORY_STALL,
+                        trace_utils.CoreEvent.LOCK_STALL,
+                        trace_utils.CoreEvent.INSTR_VECTOR,
+                    ],
+                )
+
+        runtime_str = aie_ctx.module.body.operations[0].get_asm(print_generic_op_form=True)
+
+        parser = Parser(Context(allow_unregistered=True), runtime_str)
+        module = parser.parse_module()
+
+        # Find runtime sequence:
+        for runtime_sequence in op.walk():
+            if isinstance(runtime_sequence, RuntimeSequenceOp):
+                # Insert all ops at start
+                insert_point = InsertPoint.at_start(runtime_sequence.body.block)
+                for operation in module.body.block.first_op.regions[0].block.ops:
+                    if operation.op_name.data in ("aie.tile", "aie.end"):
+                        continue
+                    operation.detach()
+                    rewriter.insert_op(operation, insert_point)
+                    insert_point = InsertPoint.after(operation)

--- a/stream/stages/codegen/aie_code_generation.py
+++ b/stream/stages/codegen/aie_code_generation.py
@@ -8,6 +8,7 @@ from xdsl.printer import Printer
 from zigzag.datatypes import Constants, LayerOperand
 
 from stream.compiler.dialects.stream import ComputationNodeOp, EdgeOp, EmptySSAValue, Stream, TransferOp
+from stream.compiler.transforms.aie_add_tracing_script import AIEAddTracingScript
 from stream.compiler.transforms.clear_memory_space import ClearMemorySpace
 from stream.compiler.transforms.convert_stream_to_aie import ConvertStreamToAIEPass
 from stream.cost_model.communication_manager import CommunicationLinkEvent
@@ -281,6 +282,9 @@ class AIECodeGenerationStage(Stage):
 
         # Remove custom layout attributes
         ClearMemorySpace().apply(self.context, module)
+
+        # Optionally, Add Tracing Script
+        AIEAddTracingScript().apply(self.context, module)
 
         # print output to codegen path
         file = open(self.output_path, "w")

--- a/stream/stages/codegen/aie_code_generation.py
+++ b/stream/stages/codegen/aie_code_generation.py
@@ -284,7 +284,7 @@ class AIECodeGenerationStage(Stage):
         ClearMemorySpace().apply(self.context, module)
 
         # Optionally, Add Tracing Script
-        AIEAddTracingScript().apply(self.context, module)
+        # AIEAddTracingScript().apply(self.context, module)
 
         # print output to codegen path
         file = open(self.output_path, "w")

--- a/stream/stages/codegen/aie_code_generation.py
+++ b/stream/stages/codegen/aie_code_generation.py
@@ -8,7 +8,6 @@ from xdsl.printer import Printer
 from zigzag.datatypes import Constants, LayerOperand
 
 from stream.compiler.dialects.stream import ComputationNodeOp, EdgeOp, EmptySSAValue, Stream, TransferOp
-from stream.compiler.transforms.aie_add_tracing_script import AIEAddTracingScript
 from stream.compiler.transforms.clear_memory_space import ClearMemorySpace
 from stream.compiler.transforms.convert_stream_to_aie import ConvertStreamToAIEPass
 from stream.cost_model.communication_manager import CommunicationLinkEvent


### PR DESCRIPTION
This automatically adds the code required for tracing.


It calls the mlir-aie python bindings to generate the correct MLIR for running tracing, and then this is parsed by xDSL such that we can copy it into our own IR. For this to work, the environment must be set correctly to also be able to use the mlir-aie tools. This is handled by #19 but needs to be integrated into CI. Because of this, the pass is commented out for now.